### PR TITLE
detailsearch, multisearch 구축

### DIFF
--- a/Acorn/src/main/java/com/gura/acorn/es/ElasticUtil.java
+++ b/Acorn/src/main/java/com/gura/acorn/es/ElasticUtil.java
@@ -18,6 +18,9 @@ import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.MultiSearchRequest;
+import org.elasticsearch.action.search.MultiSearchRequestBuilder;
+import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Cancellable;
@@ -29,6 +32,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.RestHighLevelClientBuilder;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -37,6 +41,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.springframework.stereotype.Service;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 
 @Service
 public class ElasticUtil {
@@ -109,31 +115,14 @@ public class ElasticUtil {
 		return response;
 	}
 	
-	//search
-	public List<Map<String, Object>> simplesearch(){
-		//search의 결과를 담아둘 List
+	//search(인덱스 전체를 search한다.)
+	public List<Map<String, Object>> simplesearch(String index, int size){
 		List<Map<String, Object>> result=new ArrayList<>();
-		SearchRequest searchRequest = new SearchRequest("gaia"); 
+		SearchRequest searchRequest = new SearchRequest(index); 
 		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder(); 
-		searchSourceBuilder.query(QueryBuilders.matchAllQuery()); 
+		searchSourceBuilder.query(QueryBuilders.matchAllQuery()).size(size); 
 		searchRequest.source(searchSourceBuilder);
 		
-//		Cancellable response=client.searchAsync(searchRequest, RequestOptions.DEFAULT, new ActionListener<SearchResponse>() {
-//		    @Override
-//		    public void onResponse(SearchResponse searchResponse) {
-//		        System.out.println("ES로부터 정보를 가져옵니다.");
-//		        SearchHits hits=searchResponse.getHits();
-//		        for(SearchHit hit:hits) {
-//		        	result.add(hit.getSourceAsMap());
-//		        }
-//		    }
-//
-//		    @Override
-//		    public void onFailure(Exception e) {
-//		        System.out.println("search작업 실패");
-//		        System.out.println(e);
-//		    }
-//		});
 		try {
 			SearchResponse response=client.search(searchRequest, RequestOptions.DEFAULT);
 			SearchHits hits=response.getHits();
@@ -145,6 +134,74 @@ public class ElasticUtil {
 			e.printStackTrace();
 		}
 		
+		return result;
+	}
+	
+	//search(조건을 걸어 검색한다.)
+	//matchQuery : analyzer로 분석하여 형태소에 걸맞는 정보를 순서에 상관없이 출력한다.
+	//ex)2023-10-10으로 검색했을때 10이란 숫자가 date의 시간 10:00의 10도 정답인것으로 인지한다.
+	//matchphraseQuery : 위와 같은 형태지만 문자열의 순서를 지킨다.(어지간해선 이걸 쓰는게 좋다.)
+	//termQuery : 정확히 내용이 일치하는 것만 출력한다.(id로만 쓰자. 나머지는 제대로 작동안함)
+	public List<Map<String, Object>> detailsearch(String index, String field, String text, int size){
+		List<Map<String, Object>> result=new ArrayList<>();
+		String condition = "";
+		SearchResponse response= null;
+		SearchRequest searchRequest = new SearchRequest(index); 
+		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder(); 
+		if(field.equals("date")) {
+			condition = "20"+ text;
+			searchSourceBuilder.query(QueryBuilders.matchPhraseQuery(field, condition)).size(size); 
+		}else if(field.equals("url")){
+			condition = "http://localhost:9200/"+text;
+			searchSourceBuilder.query(QueryBuilders.matchPhraseQuery(field, condition)).size(size); 
+		}else {
+			condition = text;
+			searchSourceBuilder.query(QueryBuilders.termQuery(field, condition)).size(size); 
+		}
+		searchRequest.source(searchSourceBuilder);
+		
+		try {
+			response=client.search(searchRequest, RequestOptions.DEFAULT);
+			SearchHits hits=response.getHits();
+			for (SearchHit hit:hits) {
+				result.add(hit.getSourceAsMap());
+				
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return result;
+	}
+	//조건을 여러개 걸어서 검색
+	//parameter는 어떻게 조건이 걸릴지 몰라서 일단은 detailsearch와 동일하게 정해뒀음. 
+	//size 말곤 실제로 쓰지는 않음.
+	public List<Map<String, Object>> multisearch(String index, String field, String text, int size){
+		List<Map<String, Object>> result=new ArrayList<>();
+		String condition = "";
+		SearchResponse response= null;
+		SearchRequest searchRequest = new SearchRequest(index); 
+		SearchSourceBuilder sSBuilder = new SearchSourceBuilder();
+		//BoolQuery로 id조건과 date 조건을 등록
+		//must -> 포함되어야 함
+		//must not -> 포함되면 안됨		
+		//filter, should 등의 다른 메소드들은 따로 공부해서 추가해볼 예정, 일단은 이정도만으로도 충분하다.
+		sSBuilder.query(QueryBuilders.boolQuery()
+				.must(QueryBuilders.termQuery("id", "admin"))
+				.must(QueryBuilders.matchPhraseQuery("date", "2023-04-01")));
+		//너무 길어졌으므로 사이즈를 따로 분리
+		sSBuilder.size(size);
+		searchRequest.source(sSBuilder);
+		
+		try {
+			response=client.search(searchRequest, RequestOptions.DEFAULT);
+			SearchHits hits=response.getHits();
+			for (SearchHit hit:hits) {
+				result.add(hit.getSourceAsMap());
+				
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 		return result;
 	}
 	


### PR DESCRIPTION
simple search도 가볍게 다듬었고

detailsearch라는 이름의 index, fieldName, Test를 이용해서 검색하는 유틸도 만들었습니다.

multisearch는 당장은 파라미터를 주입해서 쓰기보단, 프론트엔드쪽에서 요구하는대로 제가 만들어서 주는게 나을것같아서 고정형으로 만들었습니다.

size가 추가되서 이제 10개가 아니라 마음대로 data를 빼올 수 있습니다.